### PR TITLE
Add DualViewer option

### DIFF
--- a/examples/test_teleoperation.py
+++ b/examples/test_teleoperation.py
@@ -53,6 +53,7 @@ def main():
     env = gym.make(
         "gym_hil/PandaPickCubeGamepad-v0",
         render_mode=args.render_mode,
+        viewer_type="dual",
         image_obs=True,
         step_size=args.step_size,
         use_gamepad=not args.use_keyboard,

--- a/gym_hil/wrappers/factory.py
+++ b/gym_hil/wrappers/factory.py
@@ -15,6 +15,7 @@ from gym_hil.wrappers.viewer_wrapper import PassiveViewerWrapper
 def wrap_env(
     env: gym.Env,
     use_viewer: bool = False,
+    viewer_type: str = "single",
     use_gamepad: bool = False,
     use_gripper: bool = True,
     auto_reset: bool = False,
@@ -27,6 +28,7 @@ def wrap_env(
     Args:
         env: The base environment to wrap
         use_viewer: Whether to add a passive viewer
+        viewer_type: Whether to use a single or dual viewer
         use_gamepad: Whether to use gamepad instead of keyboard controls
         use_gripper: Whether to enable gripper control
         auto_reset: Whether to automatically reset the environment when episode ends
@@ -39,7 +41,7 @@ def wrap_env(
     """
     # Apply wrappers in the correct order
     if use_viewer:
-        env = PassiveViewerWrapper(env, show_left_ui=show_ui, show_right_ui=show_ui)
+        env = PassiveViewerWrapper(env, viewer_type=viewer_type, show_left_ui=show_ui, show_right_ui=show_ui)
 
     if use_gripper:
         env = GripperPenaltyWrapper(env, penalty=gripper_penalty)
@@ -64,6 +66,7 @@ def wrap_env(
 def make_env(
     env_id: str,
     use_viewer: bool = False,
+    viewer_type: str = "single",
     use_gamepad: bool = False,
     use_gripper: bool = True,
     auto_reset: bool = False,
@@ -77,6 +80,7 @@ def make_env(
     Args:
         env_id: The ID of the base environment to create
         use_viewer: Whether to add a passive viewer
+        viewer_type: Whether to use a single or dual viewer
         use_gamepad: Whether to use gamepad instead of keyboard controls
         use_gripper: Whether to enable gripper control
         auto_reset: Whether to automatically reset the environment when episode ends
@@ -97,6 +101,7 @@ def make_env(
     return wrap_env(
         env,
         use_viewer=use_viewer,
+        viewer_type=viewer_type,
         use_gamepad=use_gamepad,
         use_gripper=use_gripper,
         auto_reset=auto_reset,

--- a/gym_hil/wrappers/intervention_utils.py
+++ b/gym_hil/wrappers/intervention_utils.py
@@ -302,7 +302,7 @@ class GamepadController(InputController):
             y_input = self.joystick.get_axis(1)  # Up/Down (often inverted)
 
             # Right stick Y (typically axis 3 or 4)
-            z_input = self.joystick.get_axis(3)  # Up/Down for Z
+            z_input = self.joystick.get_axis(4)  # Up/Down for Z
 
             # Apply deadzone to avoid drift
             x_input = 0 if abs(x_input) < self.deadzone else x_input

--- a/gym_hil/wrappers/viewer_wrapper.py
+++ b/gym_hil/wrappers/viewer_wrapper.py
@@ -120,19 +120,6 @@ class PassiveViewerWrapper(gym.Wrapper):
                         pass
                                 # Prevent the underlying env from trying to close it again.
                 base_env._viewer = None
-            elif self.viewer_type == "dual":
-                viewer_1 = base_env._viewer_1
-                viewer_2 = base_env._viewer_2
-                if viewer_1 is not None and hasattr(viewer_1, "close") and callable(viewer_1.close):
-                    try:  # noqa: SIM105
-                        viewer_1.close()
-                    except Exception:
-                        pass
-                if viewer_2 is not None and hasattr(viewer_2, "close") and callable(viewer_2.close):
-                    try:  # noqa: SIM105
-                        viewer_2.close()
-                    except Exception:
-                        pass
 
         # 2. Close the passive viewer launched by this wrapper.
         try:  # noqa: SIM105

--- a/gym_hil/wrappers/viewer_wrapper.py
+++ b/gym_hil/wrappers/viewer_wrapper.py
@@ -28,6 +28,13 @@ class PassiveViewerWrapper(gym.Wrapper):
     environment is created so the user no longer needs to use
     ``mujoco.viewer.launch_passive`` or any context–manager boiler-plate.
 
+    Args:
+        viewer_type: Whether to use a single or dual viewer. If dual, two 
+        viewers will be opened. You can switch between fixed cameras using 
+        the [, ] keys or access a free camera mode for manual adjustments using the Esc key 
+        show_left_ui: Whether to show the left UI
+        show_right_ui: Whether to show the right UI
+
     The viewer is kept in sync after every ``reset`` and ``step`` call and is
     closed automatically when the environment itself is closed or deleted.
     """
@@ -35,36 +42,50 @@ class PassiveViewerWrapper(gym.Wrapper):
     def __init__(
         self,
         env: gym.Env,
-        *,
+        viewer_type: str = "single",
         show_left_ui: bool = False,
         show_right_ui: bool = False,
+        **kwargs,
     ) -> None:
         super().__init__(env)
-
+        self.viewer_type = viewer_type
         # Launch the interactive viewer.  We expose *model* and *data* from the
         # *unwrapped* environment to make sure we operate on the base MuJoCo
         # objects even if other wrappers have been applied before this one.
-        self._viewer = mujoco.viewer.launch_passive(
-            env.unwrapped.model,
-            env.unwrapped.data,
-            # show_left_ui=show_left_ui,
-            # show_right_ui=show_right_ui,
-        )
-
+        if self.viewer_type == "single":
+            self._viewer = mujoco.viewer.launch_passive(
+                env.unwrapped.model,
+                env.unwrapped.data,
+                # show_left_ui=show_left_ui,
+                # show_right_ui=show_right_ui,
+            )
+        elif self.viewer_type == "dual":
+            self._viewer_1 = mujoco.viewer.launch_passive(
+                env.unwrapped.model,
+                env.unwrapped.data,
+                # show_left_ui=show_left_ui,
+                # show_right_ui=show_right_ui,
+            )
+            self._viewer_2 = mujoco.viewer.launch_passive(
+                env.unwrapped.model,
+                env.unwrapped.data,
+                # show_left_ui=show_left_ui,
+                # show_right_ui=show_right_ui,
+            )
         # Make sure the first frame is rendered.
-        self._viewer.sync()
+        self._sync()
 
     # ---------------------------------------------------------------------
     # Gym API overrides
 
     def reset(self, **kwargs):  # type: ignore[override]
         observation, info = self.env.reset(**kwargs)
-        self._viewer.sync()
+        self._sync()
         return observation, info
 
     def step(self, action):  # type: ignore[override]
         observation, reward, terminated, truncated, info = self.env.step(action)
-        self._viewer.sync()
+        self._sync()
         return observation, reward, terminated, truncated, info
 
     def close(self) -> None:  # type: ignore[override]
@@ -88,20 +109,38 @@ class PassiveViewerWrapper(gym.Wrapper):
         # 1. Tidy up the renderer managed by the wrapped environment (if any).
         base_env = self.env.unwrapped  # type: ignore[attr-defined]
         if hasattr(base_env, "_viewer"):
-            viewer = base_env._viewer
-            if viewer is not None and hasattr(viewer, "close") and callable(viewer.close):
-                try:  # noqa: SIM105
-                    viewer.close()
-                except Exception:
-                    # Ignore errors coming from older MuJoCo versions or
-                    # already-freed contexts.
-                    pass
-            # Prevent the underlying env from trying to close it again.
-            base_env._viewer = None
+            if self.viewer_type == "single":
+                viewer = base_env._viewer
+                if viewer is not None and hasattr(viewer, "close") and callable(viewer.close):
+                    try:  # noqa: SIM105
+                        viewer.close()
+                    except Exception:
+                        # Ignore errors coming from older MuJoCo versions or
+                        # already-freed contexts.
+                        pass
+                                # Prevent the underlying env from trying to close it again.
+                base_env._viewer = None
+            elif self.viewer_type == "dual":
+                viewer_1 = base_env._viewer_1
+                viewer_2 = base_env._viewer_2
+                if viewer_1 is not None and hasattr(viewer_1, "close") and callable(viewer_1.close):
+                    try:  # noqa: SIM105
+                        viewer_1.close()
+                    except Exception:
+                        pass
+                if viewer_2 is not None and hasattr(viewer_2, "close") and callable(viewer_2.close):
+                    try:  # noqa: SIM105
+                        viewer_2.close()
+                    except Exception:
+                        pass
 
         # 2. Close the passive viewer launched by this wrapper.
         try:  # noqa: SIM105
-            self._viewer.close()
+            if self.viewer_type == "single":
+                self._viewer.close()
+            elif self.viewer_type == "dual":
+                self._viewer_1.close()
+                self._viewer_2.close()
         except Exception:  # pragma: no cover
             # Defensive: avoid propagating viewer shutdown errors.
             pass
@@ -114,6 +153,18 @@ class PassiveViewerWrapper(gym.Wrapper):
         # in case.
         if hasattr(self, "_viewer"):
             try:  # noqa: SIM105
-                self._viewer.close()
+                if self.viewer_type == "single":
+                    self._viewer.close()
+                elif self.viewer_type == "dual":
+                    self._viewer_1.close()
+                    self._viewer_2.close()
             except Exception:
                 pass
+
+    def _sync(self):
+        if self.viewer_type == "single":
+            self._viewer.sync()
+        elif self.viewer_type == "dual":
+            self._viewer_1.sync()
+            self._viewer_2.sync()
+


### PR DESCRIPTION
Hi as we discussed it is better to have the two viewers option for difficult tasks. I added the Dual Viewer option as a parameter `viewer_type` when making the gym environment, example can be seen at `examples/test_teleoperation.py`.
However, the viewers crash very often and I don't know why.