### PR TITLE
Fix DUALSHOCK 4 controller detection on macOS

### DIFF
--- a/gym_hil/wrappers/intervention_utils.py
+++ b/gym_hil/wrappers/intervention_utils.py
@@ -429,7 +429,7 @@ class GamepadControllerHID(InputController):
         devices = hid.enumerate()
         for device in devices:
             device_name = device["product_string"]
-            if any(controller in device_name for controller in ["Logitech", "Xbox", "PS4", "PS5"]):
+            if any(controller in device_name for controller in ["Logitech", "Xbox", "PS4", "PS5", "DUALSHOCK"]):
                 return device
 
         print("No gamepad found, check the connection and the product string in HID to add your gamepad")


### PR DESCRIPTION
## Summary
- Add "DUALSHOCK" to HID device detection pattern in `GamepadControllerHID.find_device()`
- Fixes issue where DUALSHOCK 4 Wireless Controllers are visible in system_profiler but not detected by gym-hil
- Maintains compatibility with existing controller types (Logitech, Xbox, PS4, PS5)

## Test plan
- [ ] Test with DUALSHOCK 4 Wireless Controller on macOS
- [ ] Verify existing controllers still work
- [ ] Run `python examples/test_teleoperation.py` to confirm detection

🤖 Generated with [Claude Code](https://claude.ai/code)