### PR TITLE
Add Dual Viewport Wrapper

### DIFF
--- a/examples/test_dual_views.py
+++ b/examples/test_dual_views.py
@@ -1,24 +1,26 @@
 import time
-import numpy as np
+
 import gymnasium as gym
-import gym_hil
+import numpy as np
 
-from gym_hil.wrappers.viewer_wrapper import DualViewportWrapper
+import gym_hil  # noqa: F401
 
-
-base = gym.make("gym_hil/PandaPickCubeBase-v0", render_mode=None, image_obs=False)
-env = DualViewportWrapper(base, image_size=(128, 128))
-
+env = gym.make("gym_hil/PandaPickCubeDualViewGamepad-v0")
 obs, info = env.reset()
-
-a = np.zeros(env.action_space.shape, dtype=np.float32)
+dummy_action = np.zeros(4, dtype=np.float32)
+dummy_action[-1] = 1
 
 try:
     while True:
-        obs, r, term, trunc, info = env.step(a)
+        obs, r, term, trunc, info = env.step(dummy_action)
+
+        if info.get("viewer_closed"):
+            break
 
         if term or trunc:
-            obs, info = env.reset()
+            print("Episode ended, resetting environment")
+            obs, _ = env.reset()
+
         time.sleep(0.02)
 finally:
     env.close()

--- a/examples/test_dual_views.py
+++ b/examples/test_dual_views.py
@@ -3,8 +3,14 @@ import numpy as np
 import gymnasium as gym
 import gym_hil
 
-env = gym.make("gym_hil/PandaPickCubeDualView-v0", render_mode="rgb_array", image_obs=True)
+from gym_hil.wrappers.viewer_wrapper import DualViewportWrapper
+
+
+base = gym.make("gym_hil/PandaPickCubeBase-v0", render_mode=None, image_obs=False)
+env = DualViewportWrapper(base, image_size=(128, 128))
+
 obs, info = env.reset()
+
 a = np.zeros(env.action_space.shape, dtype=np.float32)
 
 try:

--- a/examples/test_dual_views.py
+++ b/examples/test_dual_views.py
@@ -1,0 +1,18 @@
+import time
+import numpy as np
+import gymnasium as gym
+import gym_hil
+
+env = gym.make("gym_hil/PandaPickCubeDualView-v0", render_mode="rgb_array", image_obs=True)
+obs, info = env.reset()
+a = np.zeros(env.action_space.shape, dtype=np.float32)
+
+try:
+    while True:
+        obs, r, term, trunc, info = env.step(a)
+
+        if term or trunc:
+            obs, info = env.reset()
+        time.sleep(0.02)
+finally:
+    env.close()

--- a/gym_hil/__init__.py
+++ b/gym_hil/__init__.py
@@ -59,7 +59,7 @@ register(
     max_episode_steps=100,
     kwargs={
         "create_renderer": False,
-    }
+    },
 )
 
 # Register the dual viewer wrapper with gamepad

--- a/gym_hil/__init__.py
+++ b/gym_hil/__init__.py
@@ -18,7 +18,7 @@ import gymnasium as gym
 
 from gym_hil.mujoco_gym_env import FrankaGymEnv, GymRenderingSpec, MujocoGymEnv
 from gym_hil.wrappers.factory import make_env, wrap_env
-from gym_hil.wrappers.viewer_wrapper import PassiveViewerWrapper
+from gym_hil.wrappers.viewer_wrapper import PassiveViewerWrapper, DualViewportWrapper
 
 __all__ = [
     "MujocoGymEnv",
@@ -48,6 +48,13 @@ register(
 register(
     id="gym_hil/PandaPickCubeViewer-v0",
     entry_point=lambda **kwargs: PassiveViewerWrapper(gym.make("gym_hil/PandaPickCubeBase-v0", **kwargs)),
+    max_episode_steps=100,
+)
+
+# Register the dual viewer wrapper
+register(
+    id="gym_hil/PandaPickCubeDualView-v0",
+    entry_point=lambda **kw: DualViewportWrapper(gym.make("gym_hil/PandaPickCubeBase-v0", **kw), image_size=(128,128)),
     max_episode_steps=100,
 )
 

--- a/gym_hil/__init__.py
+++ b/gym_hil/__init__.py
@@ -75,6 +75,18 @@ register(
     },
 )
 
+# Register the dual viewer wrapper with Keyboard
+register(
+    id="gym_hil/PandaPickCubeDualViewKeyboard-v0",
+    entry_point="gym_hil.wrappers.factory:make_env",
+    max_episode_steps=100,
+    kwargs={
+        "env_id": "gym_hil/PandaPickCubeBase-v0",  # Use the base environment
+        "use_dual_viewer": True,
+        "create_renderer": False,
+    },
+)
+
 register(
     id="gym_hil/PandaArrangeBoxesViewer-v0",
     entry_point=lambda **kwargs: PassiveViewerWrapper(gym.make("gym_hil/PandaArrangeBoxesBase-v0", **kwargs)),

--- a/gym_hil/__init__.py
+++ b/gym_hil/__init__.py
@@ -18,13 +18,14 @@ import gymnasium as gym
 
 from gym_hil.mujoco_gym_env import FrankaGymEnv, GymRenderingSpec, MujocoGymEnv
 from gym_hil.wrappers.factory import make_env, wrap_env
-from gym_hil.wrappers.viewer_wrapper import PassiveViewerWrapper, DualViewportWrapper
+from gym_hil.wrappers.viewer_wrapper import DualViewportWrapper, PassiveViewerWrapper
 
 __all__ = [
     "MujocoGymEnv",
     "FrankaGymEnv",
     "GymRenderingSpec",
     "PassiveViewerWrapper",
+    "DualViewportWrapper",
     "make_env",
     "wrap_env",
 ]
@@ -54,8 +55,24 @@ register(
 # Register the dual viewer wrapper
 register(
     id="gym_hil/PandaPickCubeDualView-v0",
-    entry_point=lambda **kw: DualViewportWrapper(gym.make("gym_hil/PandaPickCubeBase-v0", **kw), image_size=(128,128)),
+    entry_point=lambda **kwargs: DualViewportWrapper(gym.make("gym_hil/PandaPickCubeBase-v0", **kwargs)),
     max_episode_steps=100,
+    kwargs={
+        "create_renderer": False,
+    }
+)
+
+# Register the dual viewer wrapper with gamepad
+register(
+    id="gym_hil/PandaPickCubeDualViewGamepad-v0",
+    entry_point="gym_hil.wrappers.factory:make_env",
+    max_episode_steps=100,
+    kwargs={
+        "env_id": "gym_hil/PandaPickCubeBase-v0",  # Use the base environment
+        "use_dual_viewer": True,
+        "use_gamepad": True,
+        "create_renderer": False,
+    },
 )
 
 register(

--- a/gym_hil/envs/panda_pick_gym_env.py
+++ b/gym_hil/envs/panda_pick_gym_env.py
@@ -40,6 +40,7 @@ class PandaPickCubeGymEnv(FrankaGymEnv):
         image_obs: bool = False,
         reward_type: str = "sparse",
         random_block_position: bool = False,
+        create_renderer: bool = True,
     ):
         self.reward_type = reward_type
 
@@ -52,6 +53,7 @@ class PandaPickCubeGymEnv(FrankaGymEnv):
             image_obs=image_obs,
             home_position=_PANDA_HOME,
             cartesian_bounds=_CARTESIAN_BOUNDS,
+            create_renderer=create_renderer,
         )
 
         # Task-specific setup
@@ -160,11 +162,19 @@ class PandaPickCubeGymEnv(FrankaGymEnv):
 
         if self.image_obs:
             # Image observations
-            front_view, wrist_view = self.render()
-            observation = {
-                "pixels": {"front": front_view, "wrist": wrist_view},
-                "agent_pos": robot_state,
-            }
+            if self.create_renderer:
+                front_view, wrist_view = self.render()
+                observation["pixels"] = {"front": front_view, "wrist": wrist_view}
+            else:
+                observation["pixels"] = {
+                    "front": np.zeros(
+                        (self._render_specs.height, self._render_specs.width, 3), dtype=np.uint8
+                    ),
+                    "wrist": np.zeros(
+                        (self._render_specs.height, self._render_specs.width, 3), dtype=np.uint8
+                    ),
+                }
+            observation["agent_pos"] = robot_state
         else:
             # State-only observations
             observation = {

--- a/gym_hil/mujoco_gym_env.py
+++ b/gym_hil/mujoco_gym_env.py
@@ -128,6 +128,7 @@ class FrankaGymEnv(MujocoGymEnv):
         image_obs: bool = False,
         home_position: np.ndarray = np.asarray((0, -0.785, 0, -2.35, 0, 1.57, np.pi / 4)),  # noqa: B008
         cartesian_bounds: np.ndarray = np.asarray([[0.2, -0.3, 0], [0.6, 0.3, 0.5]]),  # noqa: B008
+        eager_renderer: bool = False,
     ):
         if xml_path is None:
             xml_path = Path(__file__).parent.parent / "gym_hil" / "assets" / "scene.xml"
@@ -168,9 +169,10 @@ class FrankaGymEnv(MujocoGymEnv):
         self._setup_observation_space()
         self._setup_action_space()
 
-        # Initialize renderer
-        self._viewer = mujoco.Renderer(self.model, height=render_spec.height, width=render_spec.width)
-        self._viewer.render()
+        if eager_renderer:
+            # Initialize renderer
+            self._viewer = mujoco.Renderer(self.model, height=render_spec.height, width=render_spec.width)
+            self._viewer.render()
 
     def _setup_observation_space(self):
         """Setup the observation space for the Franka environment."""

--- a/gym_hil/mujoco_gym_env.py
+++ b/gym_hil/mujoco_gym_env.py
@@ -128,7 +128,7 @@ class FrankaGymEnv(MujocoGymEnv):
         image_obs: bool = False,
         home_position: np.ndarray = np.asarray((0, -0.785, 0, -2.35, 0, 1.57, np.pi / 4)),  # noqa: B008
         cartesian_bounds: np.ndarray = np.asarray([[0.2, -0.3, 0], [0.6, 0.3, 0.5]]),  # noqa: B008
-        eager_renderer: bool = False,
+        create_renderer: bool = True,
     ):
         if xml_path is None:
             xml_path = Path(__file__).parent.parent / "gym_hil" / "assets" / "scene.xml"
@@ -150,6 +150,7 @@ class FrankaGymEnv(MujocoGymEnv):
         }
 
         self.render_mode = render_mode
+        self.create_renderer = create_renderer
         self.image_obs = image_obs
 
         # Setup cameras
@@ -169,7 +170,7 @@ class FrankaGymEnv(MujocoGymEnv):
         self._setup_observation_space()
         self._setup_action_space()
 
-        if eager_renderer:
+        if self.create_renderer:
             # Initialize renderer
             self._viewer = mujoco.Renderer(self.model, height=render_spec.height, width=render_spec.width)
             self._viewer.render()

--- a/gym_hil/mujoco_gym_env.py
+++ b/gym_hil/mujoco_gym_env.py
@@ -117,6 +117,11 @@ class MujocoGymEnv(gym.Env):
 class FrankaGymEnv(MujocoGymEnv):
     """Base class for Franka Panda robot environments."""
 
+    metadata = {
+        "render_modes": ["human", "rgb_array"],
+        "render_fps": 50,
+    }
+
     def __init__(
         self,
         xml_path: Path | None = None,
@@ -144,11 +149,7 @@ class FrankaGymEnv(MujocoGymEnv):
         self._home_position = home_position
         self._cartesian_bounds = cartesian_bounds
 
-        self.metadata = {
-            "render_modes": ["human", "rgb_array"],
-            "render_fps": int(np.round(1.0 / self.control_dt)),
-        }
-
+        self.metadata["render_fps"] = int(np.round(1.0 / self.control_dt))
         self.render_mode = render_mode
         self.create_renderer = create_renderer
         self.image_obs = image_obs
@@ -262,7 +263,7 @@ class FrankaGymEnv(MujocoGymEnv):
 
     def get_robot_state(self):
         """Get the current state of the robot."""
-        tcp_pos = self._data.sensor("2f85/pinch_pos").data
+        tcp_pos = self._data.sensor("2f85/pinch_pos").data.astype(np.float32)
         # tcp_quat = self._data.sensor("2f85/pinch_quat").data
         # tcp_vel = self._data.sensor("2f85/pinch_vel").data
         # tcp_angvel = self._data.sensor("2f85/pinch_angvel").data

--- a/gym_hil/wrappers/factory.py
+++ b/gym_hil/wrappers/factory.py
@@ -13,7 +13,7 @@ from gym_hil.wrappers.hil_wrappers import (
     InputsControlWrapper,
     ResetDelayWrapper,
 )
-from gym_hil.wrappers.viewer_wrapper import PassiveViewerWrapper
+from gym_hil.wrappers.viewer_wrapper import DualViewportWrapper, PassiveViewerWrapper
 
 
 class EEActionStepSize(TypedDict):
@@ -26,6 +26,7 @@ def wrap_env(
     env: gym.Env,
     ee_step_size: EEActionStepSize | None = None,
     use_viewer: bool = False,
+    use_dual_viewer: bool = False,
     use_gamepad: bool = False,
     use_gripper: bool = True,
     use_inputs_control: bool = False,
@@ -78,6 +79,9 @@ def wrap_env(
     if use_viewer:
         env = PassiveViewerWrapper(env, show_left_ui=show_ui, show_right_ui=show_ui)
 
+    if use_dual_viewer:
+        env = DualViewportWrapper(env)
+
     # Apply time delay wrapper
     env = ResetDelayWrapper(env, delay_seconds=reset_delay_seconds)
 
@@ -88,6 +92,7 @@ def make_env(
     env_id: str,
     ee_step_size: EEActionStepSize | None = None,
     use_viewer: bool = False,
+    use_dual_viewer: bool = False,
     use_gamepad: bool = False,
     use_gripper: bool = True,
     use_inputs_control: bool = False,
@@ -129,6 +134,7 @@ def make_env(
         env,
         ee_step_size=ee_step_size,
         use_viewer=use_viewer,
+        use_dual_viewer=use_dual_viewer,
         use_gamepad=use_gamepad,
         use_gripper=use_gripper,
         use_inputs_control=use_inputs_control,

--- a/gym_hil/wrappers/hil_wrappers.py
+++ b/gym_hil/wrappers/hil_wrappers.py
@@ -70,13 +70,13 @@ class EEActionWrapper(gym.ActionWrapper):
         action_space_bounds_max = np.ones(num_actions)
 
         if self.use_gripper:
-            action_space_bounds_min = np.concatenate([action_space_bounds_min, [0.0]])
-            action_space_bounds_max = np.concatenate([action_space_bounds_max, [2.0]])
+            action_space_bounds_min = np.concatenate([action_space_bounds_min, [-1.0]])
+            action_space_bounds_max = np.concatenate([action_space_bounds_max, [1.0]])
             num_actions += 1
 
         ee_action_space = gym.spaces.Box(
-            low=action_space_bounds_min,
-            high=action_space_bounds_max,
+            low=action_space_bounds_min.astype(np.float32),
+            high=action_space_bounds_max.astype(np.float32),
             shape=(num_actions,),
             dtype=np.float32,
         )
@@ -97,7 +97,7 @@ class EEActionWrapper(gym.ActionWrapper):
         gripper_open_command = [0.0]
         if self.use_gripper:
             # NOTE: Normalize gripper action from [0, 2] -> [-1, 1]
-            gripper_open_command = [action[-1] - 1.0]
+            gripper_open_command = [action[-1]]
 
         action = np.concatenate([action_xyz, actions_orn, gripper_open_command])
         return action
@@ -192,11 +192,11 @@ class InputsControlWrapper(gym.Wrapper):
         if self.use_gripper:
             gripper_command = self.controller.gripper_command()
             if gripper_command == "open":
-                gamepad_action = np.concatenate([gamepad_action, [2.0]])
-            elif gripper_command == "close":
-                gamepad_action = np.concatenate([gamepad_action, [0.0]])
-            else:
                 gamepad_action = np.concatenate([gamepad_action, [1.0]])
+            elif gripper_command == "close":
+                gamepad_action = np.concatenate([gamepad_action, [-1.0]])
+            else:
+                gamepad_action = np.concatenate([gamepad_action, [0.0]])
 
         # Check episode ending buttons
         # We'll rely on controller.get_episode_end_status() which returns "success", "failure", or None

--- a/gym_hil/wrappers/viewer_wrapper.py
+++ b/gym_hil/wrappers/viewer_wrapper.py
@@ -259,7 +259,7 @@ class DualViewportWrapper(gym.Wrapper):
         """Clean up resources and close the environment."""
         if hasattr(self, "_renderers"):
             for renderer in self._renderers.values():
-                try: # noqa: SIM105
+                try:  # noqa: SIM105
                     renderer.close()
                 except Exception:
                     pass

--- a/gym_hil/wrappers/viewer_wrapper.py
+++ b/gym_hil/wrappers/viewer_wrapper.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import gymnasium as gym
 import mujoco
 import mujoco.viewer
+import numpy as np
 
 from mujoco.glfw import glfw
 

--- a/gym_hil/wrappers/viewer_wrapper.py
+++ b/gym_hil/wrappers/viewer_wrapper.py
@@ -259,7 +259,7 @@ class DualViewportWrapper(gym.Wrapper):
         """Clean up resources and close the environment."""
         if hasattr(self, "_renderers"):
             for renderer in self._renderers.values():
-                try:
+                try: # noqa: SIM105
                     renderer.close()
                 except Exception:
                     pass


### PR DESCRIPTION
# What this does

* This PR introduces a **DualViewportWrapper**.
* **GLFW Window** side-by-side (“dual viewport”) rendering of two cameras in real time for teleoperation.
* **Offscreen Renderer** independent rendering of policy observations at configurable resolutions.
* Small offscreen renderer for RL observation to keeps simulation efficient.
* Separate GLFW window for operator to does not interfere with policy image capture with high resolution and real-time resizing.
* Different resolutions possible for front/wrist cameras for different policy (for example Octo VLA expect 256x256 front camera and 128x128 wrist camera)
<img width="1284" height="763" alt="image" src="https://github.com/user-attachments/assets/9e4453d7-9c9e-49b5-b9f1-bcd6e47b5b46" />

# How to test it

```bash
python examples/test_dual_views.py
```

